### PR TITLE
Postmates::Error#response

### DIFF
--- a/lib/faraday/raise_http_exception.rb
+++ b/lib/faraday/raise_http_exception.rb
@@ -10,12 +10,12 @@ module FaradayMiddleware
         msg = parsed_response.is_a?(Array) ? response[:status] : "#{response[:status]} #{parsed_response['message']}"
 
         case response[:status]
-        when 400 ; raise Postmates::BadRequest,          msg
-        when 401 ; raise Postmates::Unauthorized,        msg
-        when 403 ; raise Postmates::Forbidden,           msg
-        when 404 ; raise Postmates::NotFound,            msg
-        when 500 ; raise Postmates::InternalServerError, msg
-        when 503 ; raise Postmates::ServiceUnavailable,  msg
+        when 400 ; raise Postmates::BadRequest.new(response), msg
+        when 401 ; raise Postmates::Unauthorized.new(response), msg
+        when 403 ; raise Postmates::Forbidden.new(response), msg
+        when 404 ; raise Postmates::NotFound.new(response), msg
+        when 500 ; raise Postmates::InternalServerError.new(response), msg
+        when 503 ; raise Postmates::ServiceUnavailable.new(response), msg
         end
       end
     end

--- a/lib/postmates/error.rb
+++ b/lib/postmates/error.rb
@@ -1,5 +1,12 @@
 module Postmates
-  class Error       < StandardError; end # custom Postmates error class
+  class Error < RuntimeError
+    attr_accessor :response
+
+    def initialize(response)
+      @response = response
+    end
+  end # custom Postmates error class
+
   class BadRequest          < Error; end # 400
   class Unauthorized        < Error; end # 401
   class Forbidden           < Error; end # 403

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -13,7 +13,7 @@ describe Postmates::Error do
 
       it 'raises Postmates::BadRequest' do
         expect { client.create }
-          .to raise_error Postmates::BadRequest
+          .to raise_error(Postmates::BadRequest) { |error| expect(error.response.status).to eq(400) }
       end
     end
 
@@ -26,7 +26,7 @@ describe Postmates::Error do
 
       it 'raises Postmates::Unauthorized' do
         expect { bad_client.list }
-          .to raise_error Postmates::Unauthorized
+          .to raise_error(Postmates::Unauthorized) { |error| expect(error.response.status).to eq(401) }
       end
     end
 
@@ -39,7 +39,7 @@ describe Postmates::Error do
 
       it 'raises Postmates::Forbidden' do
         expect { bad_client.list }
-          .to raise_error Postmates::Forbidden
+          .to raise_error(Postmates::Forbidden) { |error| expect(error.response.status).to eq(403) }
       end
     end
 
@@ -51,7 +51,7 @@ describe Postmates::Error do
 
       it 'raises Postmates::NotFound' do
         expect { client.retrieve('bad-id') }
-          .to raise_error Postmates::NotFound
+          .to raise_error(Postmates::NotFound) { |error| expect(error.response.status).to eq(404) }
       end
     end
 
@@ -63,7 +63,7 @@ describe Postmates::Error do
 
       it 'raises Postmates::InternalServerError' do
         expect { client.list }
-          .to raise_error Postmates::InternalServerError
+          .to raise_error(Postmates::InternalServerError) { |error| expect(error.response.status).to eq(500) }
       end
     end
 
@@ -75,7 +75,7 @@ describe Postmates::Error do
 
       it 'raises Postmates::ServiceUnavailable' do
         expect { client.list }
-          .to raise_error Postmates::ServiceUnavailable
+          .to raise_error(Postmates::ServiceUnavailable) { |error| expect(error.response.status).to eq(503) }
       end
     end
   end


### PR DESCRIPTION
All `Postmates::Error` instances now carry the original `Faraday` response for further inspection.
